### PR TITLE
Removed NFS configuration lines; stop using NFS for synced directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,10 +20,7 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  config.vm.synced_folder ".", "/vagrant",
-    :nfs => true,
-    :mount_options => ['actimeo=2']
-
+  config.vm.synced_folder ".", "/vagrant"
 
   config.vm.provider :virtualbox do |v|
     v.name = "tableland"


### PR DESCRIPTION
Issues with using a NFS share for the Vagrant synced folder caused the
sqlite database to be locked and not modifiable by Rails. This was a
problem for our Linux development machines; it worked OK for Macs.
The solution is to stop using NFS for the synced directory, and just
use the native VirtualBox shared folder facilities.

The advantage of using NFS is that there may be a performance penalty
when using the standard shared folder scheme. It is possible that
this issue could be fixed by following instructions on the following
page:

https://www.vagrantup.com/docs/synced-folders/nfs.html

A similar issue is mentioned in this stackoverflow post:

https://stackoverflow.com/questions/38673701/new-sqlite3-database-is-locked

"One should note that POSIX advisory locking is known to be buggy or
even unimplemented on many NFS implementations ... Your best defense is
to not use SQLite for files on a network filesystem."