### PR TITLE
[#105] rewrite create reducer to not use ramda

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,6 +1,6 @@
 import { map, identity } from 'ramda'
 import { camelizeKeys, decamelizeKeys } from 'humps'
-import { CALL_API, ApiError, getJSON } from 'redux-api-middleware'
+import { RSAA, ApiError, getJSON } from 'redux-api-middleware'
 
 // identity used as a default function see http://ramdajs.com/docs/#identity
 const defaultCallback = { onSuccess: identity }
@@ -15,7 +15,7 @@ export function callApi(callDescriptor, callbacks = {}) {
 
   return dispatch =>
     dispatch({
-      [CALL_API]: {
+      [RSAA]: {
         body: JSON.stringify(decamelizeKeys), // TODO test on POST request
         endpoint,
         method: method || 'GET',

--- a/client/src/utils/createReducer.js
+++ b/client/src/utils/createReducer.js
@@ -1,6 +1,12 @@
-import { identity, propOr } from 'ramda'
+// generates reducers to reducer boilerplate code
+// see https://redux.js.org/docs/recipes/ReducingBoilerplate.html#generating-reducers
 
 export default function createReducer(initialState, handlers) {
-  return (state = initialState, action) =>
-    propOr(identity, action.type, handlers)(state, action)
+  return function reducer(state = initialState, action) {
+    if (handlers.hasOwnProperty(action.type)) {
+      return handlers[action.type](state, action)
+    } else {
+      return state
+    }
+  }
 }


### PR DESCRIPTION
This makes things clearer and conforms to the example in the redux docs

- changed CALL_API to RSAA in api.js ( they are aliases, CALL_API is being depreciated in a later version of redux-api-middleware)