### PR TITLE
Features/admin jointable 112

### DIFF
--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -2,9 +2,14 @@ class Organization < ApplicationRecord
   # Associations
   has_many :experiences, dependent: :destroy
   has_many :users, through: :experiences
+  
   has_many :sponsors, dependent: :destroy
   has_many :programs, through: :sponsors
+  
   has_many :media, as: :mediable, dependent: :destroy
+  
+  has_many :permissions, dependent: :destroy
+  has_many :admins, through: :permissions, source: :user
 
   # Validations
   validates :name, :visible, :address_line_1, :address_line_2, :city, :country, presence: true

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,5 +12,6 @@ class Organization < ApplicationRecord
   has_many :admins, through: :permissions, source: :user
 
   # Validations
-  validates :name, :visible, :address_line_1, :address_line_2, :city, :country, presence: true
+  validates :name, :address_line_1, :address_line_2, :city, :country, presence: true
+  validates :visible, inclusion: { in: [true, false] }
 end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,0 +1,2 @@
+class Permission < ApplicationRecord
+end

--- a/app/models/permission.rb
+++ b/app/models/permission.rb
@@ -1,2 +1,10 @@
 class Permission < ApplicationRecord
+  # Associations
+  belongs_to :user
+  belongs_to :organization, optional: true
+  belongs_to :program, optional: true
+  
+  # Validations
+  validates :user_id, presence: true
+  validates :program_id, absence: true, if: :organization_id?
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -7,10 +7,11 @@ class Program < ApplicationRecord
   has_many :organizations, through: :sponsors
 
   has_many :media, as: :mediable, dependent: :destroy
-  
+
   has_many :permissions, dependent: :destroy
   has_many :admins, through: :permissions, source: :user
 
   # Validations
-  validates :name, :visible, presence: true
+  validates :name, presence: true
+  validates :visible, inclusion: { in: [true, false] }
 end

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -2,9 +2,14 @@ class Program < ApplicationRecord
   # Associations
   has_many :experiences, dependent: :destroy
   has_many :users, through: :experiences
+
   has_many :sponsors, dependent: :destroy
   has_many :organizations, through: :sponsors
+
   has_many :media, as: :mediable, dependent: :destroy
+  
+  has_many :permissions, dependent: :destroy
+  has_many :admins, through: :permissions, source: :user
 
   # Validations
   validates :name, :visible, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,12 @@ class User < ApplicationRecord
   has_many :experiences, dependent: :destroy
   has_many :organizations, through: :experiences
   has_many :programs, through: :experiences
+
   has_many :media, as: :mediable, dependent: :destroy
+  
+  has_many :permissions, dependent: :destroy
+  has_many :org_edits, through: :permissions, source: :organization
+  has_many :prog_edits, through: :permissions, source: :program
 
   # Validations
   validates :first_name, :last_name, :linkedin_id, :contact_url, :visible, :role, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,11 +5,12 @@ class User < ApplicationRecord
   has_many :programs, through: :experiences
 
   has_many :media, as: :mediable, dependent: :destroy
-  
+
   has_many :permissions, dependent: :destroy
   has_many :org_edits, through: :permissions, source: :organization
   has_many :prog_edits, through: :permissions, source: :program
 
   # Validations
-  validates :first_name, :last_name, :linkedin_id, :contact_url, :visible, :role, presence: true
+  validates :first_name, :last_name, :linkedin_id, :contact_url, :role, presence: true
+  validates :visible, inclusion: { in: [true, false] }
 end

--- a/db/migrate/20180207061522_create_permissions.rb
+++ b/db/migrate/20180207061522_create_permissions.rb
@@ -1,0 +1,11 @@
+class CreatePermissions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :permissions do |t|
+      t.belongs_to :user, index: true
+      t.belongs_to :organization, index: true
+      t.belongs_to :program, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180127013822) do
+ActiveRecord::Schema.define(version: 20180207061522) do
 
   create_table "experiences", force: :cascade do |t|
     t.integer "user_id"
@@ -53,6 +53,17 @@ ActiveRecord::Schema.define(version: 20180127013822) do
     t.string "country"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "permissions", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "organization_id"
+    t.integer "program_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["organization_id"], name: "index_permissions_on_organization_id"
+    t.index ["program_id"], name: "index_permissions_on_program_id"
+    t.index ["user_id"], name: "index_permissions_on_user_id"
   end
 
   create_table "programs", force: :cascade do |t|

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -1,11 +1,9 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-one:
-  user_id: 1
-  organization_id: 1
-  program_id: 1
+natsumi_admin_intel:
+  user: natsumi
+  organization: intel
 
-two:
-  user_id: 1
-  organization_id: 1
-  program_id: 1
+natsumi_admin_robotics:
+  user: natsumi
+  program: robotics

--- a/test/fixtures/permissions.yml
+++ b/test/fixtures/permissions.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user_id: 1
+  organization_id: 1
+  program_id: 1
+
+two:
+  user_id: 1
+  organization_id: 1
+  program_id: 1

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PermissionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/permission_test.rb
+++ b/test/models/permission_test.rb
@@ -1,7 +1,17 @@
 require 'test_helper'
 
 class PermissionTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  
+  def setup
+    @permission = permissions(:natsumi_admin_intel)
+  end
+
+  test "should be valid" do
+    assert @permission.valid?, "Initial permission is not valid"
+  end
+
+  test "required fields should be present" do
+    nil_required_field(@permission, :user_id)
+  end
+
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -45,6 +45,22 @@ class UserTest < ActiveSupport::TestCase
     end
   end
 
+  test "should not become associated with both an organization and program through a single experience" do
+    organization = organizations(:nike)
+    if organization.nil? # if the fixtures are modified, this is a fail safe
+      organization = Organization.create!(name:"Nike", visible:true, address_line_1:"392", address_line_2:"SE Road Ave.", city:"Portland", country:"USA")
+    end
+
+    program = programs(:science)
+    if program.nil? # if the fixtures are modified, this is a fail safe
+      program = Program.create!(name:"Science Lab", visible:true)
+    end
+
+    assert_raises ActiveRecord::RecordInvalid do
+      @user.experiences.create!(organization_id:organization.id, program_id:program.id, start_date:Time.now, title:"Wrong")
+    end
+  end
+
   test "upon destroy, should have its associated experiences destroyed" do
     if @user.experiences.empty? # if the fixtures are modified, this is a fail safe
       program = Program.create!(name:"Science Lab", visible:true)
@@ -58,6 +74,44 @@ class UserTest < ActiveSupport::TestCase
     end
 
     assert @user.experiences.empty?, "Destroying the user did not dissociate their experiences"
+  end
+
+  test "should be allowed to associate with just an organization through one permission" do
+    organization = organizations(:nike)
+    if organization.nil? # if the fixtures are modified, this is a fail safe
+      organization = Organization.create!(name:"Nike", visible:true, address_line_1:"392", address_line_2:"SE Road Ave.", city:"Portland", country:"USA")
+    end
+
+    assert_difference 'Permission.count', 1, "Association between user and organization through permissions failed" do
+      @user.org_edits << organization
+    end
+  end
+
+  test "should be allowed to associate with just a program through one permission" do
+    program = programs(:science)
+    if program.nil? # if the fixtures are modified, this is a fail safe
+      program = Program.create!(name:"Science Lab", visible:true)
+    end
+
+    assert_difference 'Permission.count', 1, "Association between user and organization through permissions failed" do
+      @user.prog_edits << program
+    end
+  end
+
+  test "should not become associated with both an organization and program through a single permission" do
+    organization = organizations(:nike)
+    if organization.nil? # if the fixtures are modified, this is a fail safe
+      organization = Organization.create!(name:"Nike", visible:true, address_line_1:"392", address_line_2:"SE Road Ave.", city:"Portland", country:"USA")
+    end
+
+    program = programs(:science)
+    if program.nil? # if the fixtures are modified, this is a fail safe
+      program = Program.create!(name:"Science Lab", visible:true)
+    end
+
+    assert_raises ActiveRecord::RecordInvalid do
+      @user.permissions.create!(organization_id:organization.id, program_id:program.id)
+    end
   end
 
 end


### PR DESCRIPTION
New join table model between users and organizations for representing the connection between organization admins and the organizations that they have been given permission to edit. The new model will be called Permission, which means the actual table will be called permissions.
A User will have many permissions
A User will have many org_edits (alias for organizations) through permissions
An Organization will have many permissions
An Organization will have many admins (alias for users) through permissions

After some consideration, I decided I will be adding programs to this relationship as well in case we find the need to manage programs in a similar way. I would rather add it now and not use it then not add it now and end up needing it down the line. So,
A User will have many prog_edits (alias for programs) through permissions
A Program will have many permissions
A Program will have many admins (alias for users) through permissions