### PR TITLE
[#123] Add ‘primary’ boolean attribute to Experience model for indica…

### DIFF
--- a/db/migrate/20180215195530_add_primary_to_experiences.rb
+++ b/db/migrate/20180215195530_add_primary_to_experiences.rb
@@ -1,0 +1,5 @@
+class AddPrimaryToExperiences < ActiveRecord::Migration[5.1]
+  def change
+    add_column :experiences, :primary, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180213044623) do
+ActiveRecord::Schema.define(version: 20180215195530) do
 
   create_table "experiences", force: :cascade do |t|
     t.integer "user_id"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 20180213044623) do
     t.string "award"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "primary"
     t.index ["organization_id"], name: "index_experiences_on_organization_id"
     t.index ["program_id"], name: "index_experiences_on_program_id"
     t.index ["user_id"], name: "index_experiences_on_user_id"


### PR DESCRIPTION
…ting main job/position
This new field will be used to find and/or identify which experience a user has chosen to represent their main job or position. This will be helpful when displaying their chosen title in the profile view.