### PR TITLE
Features/display_location_map_81

### DIFF
--- a/client/src/components/home/index.js
+++ b/client/src/components/home/index.js
@@ -3,7 +3,7 @@ import BottomTab from '../../constants/tabs/tabViewProfile'
 import Map from '../map'
 
 const Home = () => (
-  <div>
+  <div style={{ height: 'calc(100vh - 72px)' }} >
     <Map />
     <BottomTab />
   </div>

--- a/client/src/components/map/index.js
+++ b/client/src/components/map/index.js
@@ -1,6 +1,10 @@
 import React from 'react'
 import { compose, withProps } from 'recompose'
-import { withScriptjs, withGoogleMap, GoogleMap } from 'react-google-maps'
+import {
+  withScriptjs,
+  withGoogleMap,
+  GoogleMap
+} from 'react-google-maps'
 import mapStyle from './style.json'
 
 /*
@@ -13,9 +17,9 @@ const MyMapComponent = compose(
   withProps({
     googleMapURL:
       'https://maps.googleapis.com/maps/api/js?key=AIzaSyARRsWk_FbczyZ0RFU4STmiTxxYfnWmiBs&v=3.exp&libraries=geometry,drawing,places',
-    loadingElement: <div style={{ height: `100%` }} />,
-    containerElement: <div style={{ height: `88vh` }} />,
-    mapElement: <div style={{ height: `100%` }} />
+      loadingElement: <div style={{ height: `100%` }} />,
+      containerElement: <div style={{ height: 'calc(100vh - 72px)' }} />,
+      mapElement: <div style={{ height: `100%` }} />
   }),
   withScriptjs,
   withGoogleMap


### PR DESCRIPTION
Fixed position issue causing map to extend off screen, creating undesired vertical scrollbar. The map now sticks to 8px from the bottom of the page. As long as the window isn't short enough (in width) that the navbar goes off scree, then the map stays entirely on screen as well, and no scrollbars appear.