### PR TITLE
[#133] Change Experience model ‘primary’ field to ‘current’

### DIFF
--- a/app/controllers/api/v1/experiences_controller.rb
+++ b/app/controllers/api/v1/experiences_controller.rb
@@ -71,11 +71,11 @@ module Api::V1
 
       # Refactor these to be one method that takes a parameter for appropriate ID
       def organization_experience_params
-        params.require(:experience).permit(:user_id, :organization_id, :start_date, :end_date, :title, :award, :primary)
+        params.require(:experience).permit(:user_id, :organization_id, :start_date, :end_date, :title, :award, :current)
       end
 
       def program_experience_params
-        params.require(:experience).permit(:user_id, :program_id, :start_date, :end_date, :title, :award, :primary)
+        params.require(:experience).permit(:user_id, :program_id, :start_date, :end_date, :title, :award, :current)
       end
 
   end

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -12,6 +12,6 @@ class Experience < ApplicationRecord
   validates :program_id, absence: true, if: :organization_id?
 
   def set_default_attributes
-    self.primary ||= false
+    self.current ||= false
   end
 end

--- a/app/serializers/api/v1/experience_serializer.rb
+++ b/app/serializers/api/v1/experience_serializer.rb
@@ -7,7 +7,7 @@ module Api::V1
                 :end_date,
                 :title,
                 :award,
-                :primary,
+                :current,
                 :link
     
     # Methods for custom attributes and associations

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -17,12 +17,12 @@ module Api::V1
       object.class.name
     end
     def main_title
-      object.experiences.where(primary: true).pluck(:title).first
+      object.experiences.where(current: true).pluck(:title).first
     end
     def main_location
-      primary_organization, primary_program = object.experiences.where(primary: true).pluck(:organization_id, :program_id).first
-      return object.organizations.where(id: primary_organization).pluck(:name).first if primary_organization.present?
-      object.programs.where(id: primary_program).pluck(:name).first if primary_program.present?
+      current_organization, current_program = object.experiences.where(current: true).pluck(:organization_id, :program_id).first
+      return object.organizations.where(id: current_organization).pluck(:name).first if current_organization.present?
+      object.programs.where(id: current_program).pluck(:name).first if current_program.present?
     end
     def link
       view_context.v1_user_url(object)

--- a/db/migrate/20180227231144_rename_primary_to_current.rb
+++ b/db/migrate/20180227231144_rename_primary_to_current.rb
@@ -1,0 +1,5 @@
+class RenamePrimaryToCurrent < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :experiences, :primary, :current
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180226082109) do
+ActiveRecord::Schema.define(version: 20180227231144) do
 
   create_table "experiences", force: :cascade do |t|
     t.integer "user_id"
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 20180226082109) do
     t.string "award"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "primary"
+    t.boolean "current"
     t.index ["organization_id"], name: "index_experiences_on_organization_id"
     t.index ["program_id"], name: "index_experiences_on_program_id"
     t.index ["user_id"], name: "index_experiences_on_user_id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -75,7 +75,7 @@ def create_experiences()
           end_date:        nil,
           title:           Faker::Company.profession,
           award:           Faker::Educator.course,
-          primary:         true
+          current:         true
          )
       else
         Experience.create( 
@@ -85,7 +85,7 @@ def create_experiences()
           end_date:        j.years.ago,
           title:           Faker::Company.profession,
           award:           Faker::Educator.course,
-          primary:         false
+          current:         false
          )
       end
     end
@@ -101,7 +101,7 @@ def create_experiences()
         start_date:      (j*2).years.ago,
         end_date:        j.years.ago,
         title:           "Member",
-        primary:         false
+        current:         false
       )
     end
   end


### PR DESCRIPTION
- primary is a SQL reserved word, so the change is necessary to avoid issues and conflicts in queries.
- verified from client view and through Postman