### PR TITLE
[#135] Updates/fixes for permissions related endpoints and workflows

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -8,7 +8,7 @@ module Api::V1
       render json: @users, include: 'media', status: :ok
     end
 
-    # GET /v1/users/permissions
+    # GET /v1/users/current/permissions
     def permissions
       # Make checks on current_user role
       render json: current_user, serializer: PermissionsSerializer, status: :ok

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,6 +1,6 @@
 module Api::V1
   class UsersController < ApiBaseController
-    before_action :set_user, only: [:permissions, :show, :update, :destroy]
+    before_action :set_user, only: [:show, :update, :destroy]
 
     # GET /v1/users
     def index
@@ -8,9 +8,10 @@ module Api::V1
       render json: @users, include: 'media', status: :ok
     end
 
-    # GET /v1/users/{id}/permissions
+    # GET /v1/users/permissions
     def permissions
-      render json: @user, serializer: PermissionsSerializer, status: :ok
+      # Make checks on current_user role
+      render json: current_user, serializer: PermissionsSerializer, status: :ok
     end
 
     # GET /v1/users/{id}

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -12,7 +12,7 @@ class Organization < ApplicationRecord
   has_many :media, as: :mediable, dependent: :destroy
   
   has_many :permissions, dependent: :destroy
-  has_many :admins, through: :permissions, source: :user
+  has_many :admins, -> { distinct }, through: :permissions, source: :user
 
   # Validations
   validates :name, :address_line_1, :address_line_2, :city, :country, presence: true

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -12,7 +12,7 @@ class Program < ApplicationRecord
   has_many :media, as: :mediable, dependent: :destroy
 
   has_many :permissions, dependent: :destroy
-  has_many :admins, through: :permissions, source: :user
+  has_many :admins, -> { distinct }, through: :permissions, source: :user
 
   # Validations
   validates :name, presence: true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -44,8 +44,8 @@ class User < ApplicationRecord
   has_many :media, as: :mediable, dependent: :destroy
 
   has_many :permissions, dependent: :destroy
-  has_many :org_edits, through: :permissions, source: :organization
-  has_many :prog_edits, through: :permissions, source: :program
+  has_many :org_edits, -> { distinct }, through: :permissions, source: :organization
+  has_many :prog_edits, -> { distinct }, through: :permissions, source: :program
 
   # Validations
   validates :first_name, :last_name, :contact_url, :role, presence: true

--- a/app/serializers/api/v1/permissions_serializer.rb
+++ b/app/serializers/api/v1/permissions_serializer.rb
@@ -4,8 +4,8 @@ module Api::V1
     type :permissions
 
     # If the user is the super_admin, they should see all organizations and programs
-    attribute :organizations, if: -> { object.role == 'admin' }
-    attribute :programs, if: -> { object.role == 'admin' }
+    attribute :organizations, if: -> { object.role == 'super_admin' }
+    attribute :programs, if: -> { object.role == 'super_admin' }
 
     # Methods for custom attributes
     def organizations
@@ -24,7 +24,7 @@ module Api::V1
     end
 
     # Otherwise, if the user is an admin, they should see only their assigned permissions
-    has_many :org_edits, key: :organizations, if: -> { object.role == 'user' }
-    has_many :prog_edits, key: :programs, if: -> { object.role == 'user' }
+    has_many :org_edits, key: :organizations, if: -> { object.role == 'admin' }
+    has_many :prog_edits, key: :programs, if: -> { object.role == 'admin' }
   end
 end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -10,6 +10,7 @@ module Api::V1
                 :main_title,
                 :main_location, 
                 :role,
+                :visible,
                 :link
 
     # Methods for custom attributes

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
           collection do
             get 'random'
             get 'current'
-            get 'permissions'
+            get 'current/permissions', to: 'users#permissions'
           end
           # Create experiences for a user, update experiences for a user, destory experiences for a user
           resources :experiences, only: [:create, :update, :destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,14 +8,11 @@ Rails.application.routes.draw do
         get 'search', to: 'api_base#search'
         # Get all users (super_admin), Get a specific user with all their media and experiences, update a specific user, destroy a specific user
         resources :users, only: [:index, :show, :update, :destroy] do
-          # Get a random user
+          # Get a random user, Get the current user, Get the current user's permissions
           collection do
             get 'random'
             get 'current'
-          end
-          # Get all permissions for an admin (admins)
-          member do
-              get 'permissions'
+            get 'permissions'
           end
           # Create experiences for a user, update experiences for a user, destory experiences for a user
           resources :experiences, only: [:create, :update, :destroy]


### PR DESCRIPTION
- Add visible to serialized user payload to help FE make smart decisions about what to display.
- Check admin roles when deciding what is appropriate to serialize for an admin's permissions.
- Prevent duplicate admins/permissions from showing up in queries.
- Change v1/users/{id}/permissions endpoint from member route to collection route as v1/users/permissions endpoint. It can now only give back the current user's permissions.