### PR TITLE
[#138] Setup validations and permission checks for actions in the programs controller

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -21,6 +21,32 @@ module Api::V1
         raise ExceptionTypes::UnauthorizedError.new("Your account has been blocked") unless (current_user.visible? || current_user.super_admin?)
       end
 
+      # Validate that an existing user can be found for granting the new permission
+      # Admins can only provide an email while super admins can provide email or ID
+      def validate_grant_params
+        found_user = nil
+        email = nil
+        user_id = nil
+
+        email = params[:email]
+        user_id = params[:user_id] 
+
+        if current_user.admin?
+          raise ExceptionTypes::BadRequestError.new("An email must be provided") unless email.present?
+          found_user = User.find_by!(email: email)
+        elsif current_user.super_admin?
+          if user_id.present?
+            found_user = User.find(user_id)
+          elsif email.present?
+            found_user = User.find_by!(email: email)
+          else
+            raise ExceptionTypes::BadRequestError.new("A user ID or email must be provided")
+          end
+        end
+
+        found_user.update!(role: :admin) if found_user.user?
+        found_user
+      end
 
     private
       # Helps all controllers implicitly locate the serializers

--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -15,6 +15,13 @@ module Api::V1
       render json: @results.flatten, root: "results", include: 'media', status: :ok
     end
 
+    protected
+      # Only allow access to certain actions if the current user is visible
+      def allow_if_visible
+        raise ExceptionTypes::UnauthorizedError.new("Your account has been blocked") unless (current_user.visible? || current_user.super_admin?)
+      end
+
+
     private
       # Helps all controllers implicitly locate the serializers
       def set_serializer_namespace

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -73,33 +73,6 @@ module Api::V1
         validate_visible
       end
 
-      # Validate that an existing user can be found for granting the new permission
-      # Admins can only provide an email while super admins can provide email or ID
-      def validate_grant_params
-        found_user = nil
-        email = nil
-        user_id = nil
-
-        email = params[:email]
-        user_id = params[:user_id] 
-
-        if current_user.admin?
-          raise ExceptionTypes::BadRequestError.new("An email must be provided") unless email.present?
-          found_user = User.find_by!(email: email)
-        elsif current_user.super_admin?
-          if user_id.present?
-            found_user = User.find(user_id)
-          elsif email.present?
-            found_user = User.find_by!(email: email)
-          else
-            raise ExceptionTypes::BadRequestError.new("A user ID or email must be provided")
-          end
-        end
-
-        found_user.update!(role: :admin) if found_user.user?
-        found_user
-      end
-
       # Ensure that only super admins can view all organizations
       def check_index_permission
         raise ExceptionTypes::UnauthorizedError.new("You do not have permission to view all organizations") unless current_user.super_admin?

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -57,11 +57,6 @@ module Api::V1
         @organization = Organization.find(params[:id])
       end
 
-      # Only allow access to certain actions if the current user is visible
-      def allow_if_visible
-        raise ExceptionTypes::UnauthorizedError.new("Your account has been blocked") unless (current_user.visible? || current_user.super_admin?)
-      end
-
       # Restrict certain actions to only admins with permission for the specified organization
       def require_correct_admin
         if current_user.user?

--- a/app/controllers/api/v1/programs_controller.rb
+++ b/app/controllers/api/v1/programs_controller.rb
@@ -2,6 +2,7 @@ module Api::V1
   class ProgramsController < ApiBaseController
     before_action :set_organization, only: :create
     before_action :set_program, only: [:show, :update, :grant_permission, :admins]
+    before_action :allow_if_visible, except: [:index, :show]
 
     # GET /v1/programs
     def index
@@ -16,19 +17,14 @@ module Api::V1
 
     # POST /v1/organizations/{organization_id}/programs
     def create
-      @program = @organization.programs.new(program_params)
-      # @program = Program.new(program_params)
-
-      if @organization.save
-        render json: @program, include: '', status: :created
-      else
-        render json: @organization.errors, status: :unprocessable_entity
-      end
+      @program = Program.new(create_program_params)
+      @program = verify_and_save_program(@program)
+      render json: @program, include: '', status: :created
     end
 
     # PATCH/PUT /v1/programs/{id}
     def update
-      if @program.update(program_params)
+      if @program.update(update_program_params)
         render json: @program, include: '', status: :ok
       else
         render json: @program.errors, status: :unprocessable_entity
@@ -62,13 +58,44 @@ module Api::V1
         @organization = Organization.find(params[:organization_id])
       end
 
-      # Use callbacks to share common setup or constraints between actions.
       def set_program
         @program = Program.find(params[:id])
       end
 
-      # Never trust parameters from the scary internet, only allow the white list through.
-      def program_params
+      # Verify that the newly created program is valid and if it is, check to
+      # see if it matches an existing program at the same organization that 
+      # should be used instead. Otherwise, save the new program and connect
+      # it to the specified parent organization.
+      def verify_and_save_program(program_to_verify_and_save)
+        duplicate_program = find_duplicate(program_to_verify_and_save) if program_to_verify_and_save.valid?
+        return duplicate_program if duplicate_program.present?
+        
+        program_to_verify_and_save.save!
+        @organization.sponsors.create!(program_id: program_to_verify_and_save.id)
+
+        program_to_verify_and_save
+      end
+
+      # Attempt to find an existing program with the exact same name or
+      # almost the exact same name as the program provided as an argument
+      def find_duplicate(valid_new_program)
+        new_name = valid_new_program.name
+
+        found_duplicate = @organization
+                              .programs
+                              .where("LOWER(name) = ?", new_name.downcase)
+                              .first
+
+        found_duplicate
+      end
+
+      # Permit only the appropriate parameters for the creation of a new program
+      def create_program_params
+        params.require(:program).permit(:name)
+      end
+
+      # Permit only the appropriate parameters for the update of an existing program
+      def update_program_params
         params.require(:program).permit(:name, :description, :url, :visible)
       end
 

--- a/app/controllers/api/v1/programs_controller.rb
+++ b/app/controllers/api/v1/programs_controller.rb
@@ -145,8 +145,5 @@ module Api::V1
         params.require(:program).permit(:name, :description, :url, :visible)
       end
 
-      def admin_params
-        params.require(:admin).permit(:user_id)
-      end
   end
 end

--- a/app/controllers/api/v1/programs_controller.rb
+++ b/app/controllers/api/v1/programs_controller.rb
@@ -34,12 +34,10 @@ module Api::V1
 
     # POST /v1/programs/{id}/permissions
     def grant_permission
-      @permission = @program.permissions.new(admin_params)
-      if @program.save
-        render json: @program, include: 'admins', status: :created
-      else
-        render json: @program.errors, status: :unprocessable_entity
-      end
+      new_admin = validate_grant_params
+      @program.permissions.new(user_id: new_admin.id)
+      @program.save!
+      render json: new_admin, include: '', status: :created
     end
 
     # GET /v1/programs/{id}/admins

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -24,8 +24,9 @@ class Program < ApplicationRecord
   has_many :admins, -> { distinct }, through: :permissions, source: :user
 
   # Validations
-  validates :name, presence: true
-  validates :visible, inclusion: { in: [true, false] }
+  validates :name,    presence:   { message: "%{attribute} must be present" }
+  validates :name,    length:     { maximum: 100, message: "%{attribute} must not be longer than %{count} characters" }
+  validates :visible, inclusion:  { in: [true, false] }
 
   private
     def set_default_attributes

--- a/app/models/sponsor.rb
+++ b/app/models/sponsor.rb
@@ -4,5 +4,5 @@ class Sponsor < ApplicationRecord
   belongs_to :program
 
   # Validations
-  validates :organization_id, :program_id, presence: true
+  validates :organization_id, :program_id, presence: { message: "%{attribute} must be present" }
 end

--- a/app/serializers/api/v1/program_serializer.rb
+++ b/app/serializers/api/v1/program_serializer.rb
@@ -7,7 +7,8 @@ module Api::V1
                 :description, 
                 :url,
                 :visible,
-                :link
+                :link,
+                :parent_organization_names
 
     # Methods for custom attributes
     def type
@@ -15,6 +16,9 @@ module Api::V1
     end
     def link
       view_context.v1_program_url(object)
+    end
+    def parent_organization_names
+      object.organizations.where(visible: true).pluck(:name)
     end
 
     # Available associations


### PR DESCRIPTION
- The validations for the actions in the programs controller exist as a combined effort between conditional checks in the controller and validation checks in the model.
- Certain helper methods for actions in the organizations controller were refactored into api_base_controller if their behavior could be shared between the organizations controller and the programs controller. However, you may find that there are other methods that weren't refactored into the base that you think should be. The reason why they are not is because they are the ones that should also apply to the users controller if they did live in the base, which I have not worked out a smart and clean way to rewrite them for all three. I will revisit this refactor after finishing the last controller sanitization.