### PR TITLE
[#139] Setup validations and permission checks for actions in the media controller

### DIFF
--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -28,11 +28,8 @@ module Api::V1
 
     # PATCH/PUT /v1/{mediable}/{mediable_id}/media/{id}
     def update
-      if @medium.update(medium_params)
-        render json: @medium, include: '', status: :ok
-      else
-        render json: @medium.errors, status: :unprocessable_entity
-      end
+      @medium.update!(medium_params)
+      render json: @medium, include: '', status: :ok
     end
 
     # DELETE /v1/{mediable}/{mediable_id}/media/{id}

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -17,6 +17,10 @@ module ExceptionHandler
     rescue_from ExceptionTypes::BadRequestError do |bad_request_exception|
       render json: { error: bad_request_exception.message }, status: :unprocessable_entity
     end
+
+    rescue_from ActionController::ParameterMissing do |parameter_missing_exception|
+      render json: { error: parameter_missing_exception.message }, status: :bad_request
+    end
   end
 
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -3,5 +3,6 @@ class Medium < ApplicationRecord
   belongs_to :mediable, polymorphic: true
 
   # Validations
-  validates :mediable_id, :mediable_type, presence: true
+  validates :mediable_id, :mediable_type, :category, :url, presence: { message: "%{attribute} must be present" }
+  validates :category, inclusion: { in: %w(image video), message: "%{value} is not a valid category, must be image or video" }
 end


### PR DESCRIPTION
- The validations for the actions in the media controller exist as a combined effort between conditional checks in the controller and validation checks in the model.
- Users, organizations, and programs, may not have more than 2 media items.
- If the medium is a video, the host must be www.youtube.com and the scheme must be https
- If the medium is an image, the host must be media.licdn.com and the scheme must be https
- Category and URL are both required during creation, category must be either "image" or "video"
- Users can only modify their own media
- Admins can only modify media for organizations and programs that they have permission for.
- Super admins can modify media for any organization and any program.