### PR TITLE
[#149] Improvements to admin management functionality

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -48,6 +48,18 @@ module Api::V1
         found_user
       end
 
+      # Attempt to find admin permissions matching the specified user for the specified resource
+      def find_permissions_to_revoke(resource)
+        raise ExceptionTypes::BadRequestError.new("user_id must be present") unless params[:user_id].present?
+        
+        found_user = User.find(params[:user_id])
+        raise ExceptionTypes::UnauthorizedError.new("You are not authorized to modify the permissions for the user with ID #{found_user.id}") if found_user.super_admin?
+
+        found_permissions = resource.permissions.where(user_id: found_user.id)
+
+        found_permissions
+      end
+
     private
       # Helps all controllers implicitly locate the serializers
       def set_serializer_namespace

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -1,8 +1,8 @@
 module Api::V1
   class OrganizationsController < ApiBaseController
-    before_action :set_organization, only: [:show, :update, :grant_permission, :admins]
+    before_action :set_organization, only: [:show, :update, :grant_permission, :admins, :revoke_permission]
     before_action :allow_if_visible, except: [:index, :show] 
-    before_action :require_correct_admin, only: [:update, :grant_permission]
+    before_action :require_correct_admin, only: [:update, :grant_permission, :revoke_permission]
     before_action :validate_update_params, only: :update
     before_action :check_index_permission, only: :index
     before_action :check_get_admins_permission, only: :admins
@@ -43,6 +43,12 @@ module Api::V1
     # GET /v1/organizations/{id}/admins
     def admins
       render json: @organization, include: 'admins', status: :ok
+    end
+
+    # DELETE /v1/organizations/{id}/revoke
+    def revoke_permission
+      permissions_to_destroy = find_permissions_to_revoke(@organization)
+      permissions_to_destroy.destroy_all
     end
 
     # Unreachable

--- a/app/controllers/api/v1/organizations_controller.rb
+++ b/app/controllers/api/v1/organizations_controller.rb
@@ -2,10 +2,9 @@ module Api::V1
   class OrganizationsController < ApiBaseController
     before_action :set_organization, only: [:show, :update, :grant_permission, :admins, :revoke_permission]
     before_action :allow_if_visible, except: [:index, :show] 
-    before_action :require_correct_admin, only: [:update, :grant_permission, :revoke_permission]
+    before_action :require_correct_admin, only: [:update, :grant_permission, :admins, :revoke_permission]
     before_action :validate_update_params, only: :update
     before_action :check_index_permission, only: :index
-    before_action :check_get_admins_permission, only: :admins
 
     # GET /v1/organizations
     def index
@@ -82,11 +81,6 @@ module Api::V1
       # Ensure that only super admins can view all organizations
       def check_index_permission
         raise ExceptionTypes::UnauthorizedError.new("You do not have permission to view all organizations") unless current_user.super_admin?
-      end
-
-      # Ensure that only super admins can view all admins for a specific organization
-      def check_get_admins_permission
-        raise ExceptionTypes::UnauthorizedError.new("You do not have permission to view all admins for the specified organization") unless current_user.super_admin?
       end
 
       # Verify that the newly created organization is valid and if it is, check to

--- a/app/controllers/api/v1/programs_controller.rb
+++ b/app/controllers/api/v1/programs_controller.rb
@@ -1,9 +1,9 @@
 module Api::V1
   class ProgramsController < ApiBaseController
     before_action :set_organization, only: :create
-    before_action :set_program, only: [:show, :update, :grant_permission, :admins]
+    before_action :set_program, only: [:show, :update, :grant_permission, :admins, :revoke_permission]
     before_action :allow_if_visible, except: [:index, :show]
-    before_action :require_correct_admin, only: [:update, :grant_permission]
+    before_action :require_correct_admin, only: [:update, :grant_permission, :revoke_permission]
     before_action :validate_update_params, only: :update
     before_action :check_index_permission, only: :index
     before_action :check_get_admins_permission, only: :admins
@@ -43,6 +43,12 @@ module Api::V1
     # GET /v1/programs/{id}/admins
     def admins
       render json: @program, include: 'admins', status: :ok
+    end
+
+    # DELETE /v1/programs/{id}/revoke
+    def revoke_permission
+      permissions_to_destroy = find_permissions_to_revoke(@program)
+      permissions_to_destroy.destroy_all
     end
 
     # Unreachable

--- a/app/controllers/api/v1/programs_controller.rb
+++ b/app/controllers/api/v1/programs_controller.rb
@@ -3,10 +3,9 @@ module Api::V1
     before_action :set_organization, only: :create
     before_action :set_program, only: [:show, :update, :grant_permission, :admins, :revoke_permission]
     before_action :allow_if_visible, except: [:index, :show]
-    before_action :require_correct_admin, only: [:update, :grant_permission, :revoke_permission]
+    before_action :require_correct_admin, only: [:update, :grant_permission, :admins, :revoke_permission]
     before_action :validate_update_params, only: :update
     before_action :check_index_permission, only: :index
-    before_action :check_get_admins_permission, only: :admins
 
     # GET /v1/programs
     def index
@@ -86,11 +85,6 @@ module Api::V1
       # Ensure that only super admins can view all programs
       def check_index_permission
         raise ExceptionTypes::UnauthorizedError.new("You do not have permission to view all programs") unless current_user.super_admin?
-      end
-
-      # Ensure that only super admins can view all admins for a specific program
-      def check_get_admins_permission
-        raise ExceptionTypes::UnauthorizedError.new("You do not have permission to view all admins for the specified program") unless current_user.super_admin?
       end
 
       # Verify that the newly created program is valid and if it is, check to

--- a/app/serializers/api/v1/program_serializer.rb
+++ b/app/serializers/api/v1/program_serializer.rb
@@ -18,7 +18,7 @@ module Api::V1
       view_context.v1_program_url(object)
     end
     def parent_organization_names
-      object.organizations.where(visible: true).pluck(:name)
+      object.organizations.where(visible: true).pluck(:name, :address_line_1, :address_line_2)
     end
 
     # Available associations

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,9 +26,11 @@ Rails.application.routes.draw do
         # Get all orgs (super_admin/optional), Get a specific organization with all their media, users, and programs, create a new organization,
         # Update an org (admins)
         resources :organizations, except: :destroy do
-          # Assign an admin to an org for permission to edit (super_admin), get all admins for an org (super_admin)
+          # Assign an admin to an org for permission to edit, revoke the permission for an admin to edit an org, 
+          # and get all admins for an org
           member do
             post 'permissions', to: 'organizations#grant_permission'
+            delete 'revoke', to: 'organizations#revoke_permission'
             get 'admins'
           end
           # Create programs for an organization
@@ -40,9 +42,11 @@ Rails.application.routes.draw do
         # Get all progs (super_admin/optional), Get a specific program with all their media, users, and parent organizations,
         # Update a prog (admins)
         resources :programs, only: [:index, :show, :update] do
-          # Assign an admin to a program for permission to edit (super_admin), get all admins for a program (super_admin)
+          # Assign an admin to a program for permission to edit, revoke the permission for an admin to edit a prog,
+          # and get all admins for a program (super_admin)
           member do
             post 'permissions', to: 'programs#grant_permission'
+            delete 'revoke', to: 'programs#revoke_permission'
             get 'admins'
           end
           # Create media for progs (admins), update media for progs (admins), and destroy media for progs (admins)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,11 +8,14 @@ Rails.application.routes.draw do
         get 'search', to: 'api_base#search'
         # Get all users (super_admin), Get a specific user with all their media and experiences, update a specific user, destroy a specific user
         resources :users, only: [:index, :show, :update, :destroy] do
-          # Get a random user, Get the current user, Get the current user's permissions
+          # Get a random user, Get the current user
           collection do
             get 'random'
             get 'current'
-            get 'current/permissions', to: 'users#permissions'
+          end
+          # Get the permissions for a user
+          member do
+            get 'permissions'
           end
           # Create experiences for a user, update experiences for a user, destory experiences for a user
           resources :experiences, only: [:create, :update, :destroy]


### PR DESCRIPTION
We want super admins and admins to be able to revoke permissions on a granular level. For example, for a specified user, take away their permission to edit a specific organization or program. This PR covers this feature by adding two new endpoints for revoking permissions:
- /v1/organizations/{id}/revoke with a user_id supplied in the request body
- /v1/programs/{id}/revoke with a user_id supplied in the request body

These new endpoints have the following restrictions:
- User level current users are not authorized
- Admin level current users must have a permission for the organization or program specified by the path param and must be visible
- If the user specified by the request body param is a super admin, the request will be rejected

This PR also introduces the following related changes:
- Add first two address lines to the parent_organization_names attribute list that is part of the program payload
- Change the /v1/users/current/permissions to /v1/users/{id}/permissions so that a super admin can see the exact permissions that other admins have.
- Open up the /v1/organizations/{id}/admins and /v1/programs/{id}/admins endpoints to regular admins so that for each organization or program that they have permission for, they can see a list of other admins that have the same permission
- When a user is demoted from one of the admin levels to a role of just user, their entire permissions collection will now be destroyed.