### PR TITLE
Bugs/signed out map init

### DIFF
--- a/client/src/actions/gmap.js
+++ b/client/src/actions/gmap.js
@@ -2,16 +2,6 @@ import { push } from 'react-router-redux'
 import ActionTypes from '../constants/actionTypes'
 import callApi from '../utils/api'
 
-export function initUserMap(response, dispatch, getState) {
-  const { payload: { user: { id } } } = response
-  const { routing: { location: { pathname } } } = getState()
-
-  return initMap(response, dispatch).then(() => {
-    // Route to roadmap ONLY if on home page
-    if (pathname === '/') dispatch(push(`/roadmap/${id}`))
-  })
-}
-
 export function fetchMapProfessional(userID = 'random') {
   const callDescriptor = {
     endpoint: `/users/${userID}`,

--- a/client/src/actions/index.js
+++ b/client/src/actions/index.js
@@ -3,7 +3,6 @@ import { push } from 'react-router-redux'
 import ActionTypes from '../constants/actionTypes'
 import callApi from '../utils/api'
 import { authorizeOAuth } from './oauth'
-import { initMap, initUserMap } from './gmap'
 
 // fetch User
 export function fetchUser() {
@@ -16,8 +15,7 @@ export function fetchUser() {
     ]
   }
 
-  return dispatch =>
-    dispatch(callApi(callDescriptor, { onSuccess: initUserMap }))
+  return dispatch => dispatch(callApi(callDescriptor))
 }
 
 // Fetch Organization
@@ -48,7 +46,7 @@ export function fetchProfessional(userID = 'current') {
     ]
   }
 
-  return dispatch => dispatch(callApi(callDescriptor, { onSuccess: initMap }))
+  return dispatch => dispatch(callApi(callDescriptor))
 }
 
 export function fetchProgram(progID) {

--- a/client/src/components/map/build.js
+++ b/client/src/components/map/build.js
@@ -3,10 +3,10 @@ import { Polyline } from 'react-google-maps'
 
 const startOpacity = 0.5
 const defaultBounds = {
-  north: 45.516,
-  east: -122.679565,
-  south: 45.516,
-  west: -122.679565
+  north: 45.5231,
+  east: -122.6765,
+  south: 45.5231,
+  west: -122.6765
 }
 
 const buildPolylineGroup = (i, index, nodes) => {
@@ -64,7 +64,7 @@ const buildPolylineGroup = (i, index, nodes) => {
 export const buildBounds = locations => {
   const locationData = []
   const bounds = defaultBounds
-  const boundExtension = 0.3
+  const boundExtension = 0.1
   if (locations && locations.length > 0) {
     locations.forEach(node => {
       if (node.organization) {
@@ -84,11 +84,11 @@ export const buildBounds = locations => {
     bounds.west = Math.min(...longitudes)
   }
   // If there is only one point, or groups of points clumped together
-  if (bounds.north - bounds.south < 1) {
+  if (bounds.north - bounds.south < boundExtension) {
     bounds.north += boundExtension
     bounds.south -= boundExtension
   }
-  if (bounds.east - bounds.west < 1) {
+  if (bounds.east - bounds.west < boundExtension) {
     bounds.east += boundExtension
     bounds.west -= boundExtension
   }

--- a/client/src/components/map/gmap.js
+++ b/client/src/components/map/gmap.js
@@ -40,12 +40,11 @@ const GMap = compose(withScriptjs, withGoogleMap)(props => {
     ...otherProps
   } = props
   const polylines = buildPolylines(experienceOrgs)
-  const expLength = experienceOrgs.length
   return (
     <GoogleMap
       ref={props.onMapMounted}
       defaultZoom={8}
-      defaultCenter={{ lat: -34.397, lng: 150.644 }}
+      defaultCenter={{ lng: -122.6765, lat: 45.5231 }}
       {...otherProps}>
       {experienceOrgs.map((experience, index) => {
         const { location } = experience

--- a/client/src/components/map/index.js
+++ b/client/src/components/map/index.js
@@ -23,9 +23,12 @@ const currentMarkerImg = require('../../assets/icons/current.png')
 
 class MyMapComponent extends Component {
   componentWillMount() {
-    const { fetchProfessional, match, toggleLegend, isLegendShown } = this.props
-    if (match) {
+    const { fetchProfessional, match, toggleLegend, isLegendShown, loading } = this.props
+    // if (!loading) {
+    if (match && match.params) {
       fetchProfessional(match.params.id)
+    } else {
+      fetchProfessional('random')
     }
     if (isLegendShown && window.innerWidth < 620) {
       toggleLegend()
@@ -37,11 +40,7 @@ class MyMapComponent extends Component {
     if (loading) return <Loading />
 
     const {
-      id,
-      firstName,
-      lastName,
-      mainTitle,
-      media: { image },
+      profile: { id, firstName, lastName, mainTitle, media: { image } },
       sortedExperiences,
       currentMarker,
       isMarkerOpen,
@@ -87,7 +86,7 @@ class MyMapComponent extends Component {
           containerElement={<div className="mapContainerElement" />}
           mapElement={<div className="mapMapElement" />}
           defaultZoom={12}
-          defaultCenter={{ lat: 45.516, lng: -122.679565 }}
+          defaultCenter={{ lng: -122.6765, lat: 45.5231 }}
           defaultOptions={{
             styles: mapStyle,
             streetViewControl: false,

--- a/client/src/components/map/index.js
+++ b/client/src/components/map/index.js
@@ -22,9 +22,8 @@ const firstMarkerImg = require('../../assets/icons/first.png')
 const currentMarkerImg = require('../../assets/icons/current.png')
 
 class MyMapComponent extends Component {
-  componentWillMount() {
-    const { fetchProfessional, match, toggleLegend, isLegendShown, loading } = this.props
-    // if (!loading) {
+  componentDidMount() {
+    const { fetchProfessional, match, toggleLegend, isLegendShown } = this.props
     if (match && match.params) {
       fetchProfessional(match.params.id)
     } else {
@@ -217,12 +216,8 @@ class MyMapComponent extends Component {
 }
 
 MyMapComponent.propTypes = {
-  id: PropTypes.number.isRequired,
-  firstName: PropTypes.string.isRequired,
-  lastName: PropTypes.string.isRequired,
-  mainTitle: PropTypes.string.isRequired,
+  profile: PropTypes.object.isRequired, // eslint-disable-line
   match: PropTypes.object, // eslint-disable-line
-  media: PropTypes.object.isRequired, // eslint-disable-line
   sortedExperiences: PropTypes.array.isRequired, // eslint-disable-line
   fetchProfessional: PropTypes.func.isRequired,
   currentMarker: PropTypes.number.isRequired,

--- a/client/src/components/map/style.css
+++ b/client/src/components/map/style.css
@@ -66,7 +66,10 @@
 
 .mapProfilePreviewInfo p {
   margin: 0px;
-  margin-top: 8px;
+  margin-top: 6px;
+  white-space: normal;
+  max-width: 200px;
+  margin-left: 40px;
 }
 
 .mapProfilePreviewAvatar {

--- a/client/src/containers/map/index.js
+++ b/client/src/containers/map/index.js
@@ -39,7 +39,6 @@ const mapStateToProps = state => {
   }
 
   return {
-    // ...state.app.professionalPage,
     sortedExperiences,
     ...state.app.isLoading,
     ...state.app.roadmap,

--- a/client/src/containers/map/index.js
+++ b/client/src/containers/map/index.js
@@ -7,7 +7,7 @@ import { buildBounds } from '../../components/map/build'
 import Map from '../../components/map'
 
 const mapStateToProps = state => {
-  const { experiences } = state.app.professionalPage
+  const { experiences } = state.app.roadmap.profile
 
   const refs = {
     map: undefined
@@ -39,7 +39,7 @@ const mapStateToProps = state => {
   }
 
   return {
-    ...state.app.professionalPage,
+    // ...state.app.professionalPage,
     sortedExperiences,
     ...state.app.isLoading,
     ...state.app.roadmap,

--- a/client/src/modules/reducer/roadmap.js
+++ b/client/src/modules/reducer/roadmap.js
@@ -1,10 +1,34 @@
+import { find, propEq } from 'ramda'
 import createReducer from '../../utils/createReducer'
 import ActionTypes from '../../constants/actionTypes'
+
+const portraitImg = require('../../assets/images/portrait.png')
 
 const initialState = {
   isMarkerOpen: [],
   currentMarker: 0,
-  isLegendShown: true
+  isLegendShown: true,
+  profile: {
+    id: 0,
+    type: 'User',
+    firstName: '',
+    lastName: '',
+    description: '',
+    contactUrl: '',
+    mainTitle: '',
+    mainLocation: '',
+    role: '',
+    link: '',
+    media: {
+      image: {
+        url: ''
+      },
+      video: {
+        url: ''
+      }
+    },
+    experiences: []
+  }
 }
 
 const handlers = {
@@ -12,10 +36,31 @@ const handlers = {
   // [ActionTypes.ACTION_NAME]: actionFunction
   [ActionTypes.UPDATE_OPEN_MARKERS]: updateMarkers,
   [ActionTypes.INIT_MAP_INFO]: initMarkers,
-  [ActionTypes.TOGGLE_LEGEND]: toggleLegend
+  [ActionTypes.TOGGLE_LEGEND]: toggleLegend,
+  // [ActionTypes.RECIEVE_USER]: loadProfile,
+  [ActionTypes.RECIEVE_PROFESSIONAL]: loadProfile
 }
 
 export default createReducer(initialState, handlers)
+
+function loadProfile(state, data) {
+  const { payload: { user } } = data
+  const { media } = user
+
+  const image = find(propEq('category', 'image'))(media)
+  const video = find(propEq('category', 'video'))(media)
+
+  return {
+    ...state,
+    profile: {
+      ...user,
+      media: {
+        image: image || { url: portraitImg },
+        video: video || { url: '' }
+      }
+    }
+  }
+}
 
 function initMarkers(state, data) {
   const { payload: { isMarkerOpen } } = data

--- a/client/src/modules/reducer/roadmap.js
+++ b/client/src/modules/reducer/roadmap.js
@@ -35,23 +35,38 @@ const handlers = {
   // Pattern:
   // [ActionTypes.ACTION_NAME]: actionFunction
   [ActionTypes.UPDATE_OPEN_MARKERS]: updateMarkers,
-  [ActionTypes.INIT_MAP_INFO]: initMarkers,
   [ActionTypes.TOGGLE_LEGEND]: toggleLegend,
-  // [ActionTypes.RECIEVE_USER]: loadProfile,
-  [ActionTypes.RECIEVE_PROFESSIONAL]: loadProfile
+  [ActionTypes.RECIEVE_PROFESSIONAL]: loadMap
 }
 
 export default createReducer(initialState, handlers)
 
-function loadProfile(state, data) {
+function loadMap(state, data) {
   const { payload: { user } } = data
-  const { media } = user
+  const { media, experiences } = user
+  const isMarkerOpen = []
+  const sortedExperiences = experiences.sort(
+    (a, b) => Date.parse(a.startDate) - Date.parse(b.startDate)
+  )
+
+  let isFirst = true
+  sortedExperiences.forEach(experience => {
+    if (experience.organization) {
+      if (experience.current && isFirst) {
+        isMarkerOpen.push(true)
+        isFirst = false
+      } else {
+        isMarkerOpen.push(false)
+      }
+    }
+  })
 
   const image = find(propEq('category', 'image'))(media)
   const video = find(propEq('category', 'video'))(media)
 
   return {
     ...state,
+    isMarkerOpen,
     profile: {
       ...user,
       media: {
@@ -59,16 +74,6 @@ function loadProfile(state, data) {
         video: video || { url: '' }
       }
     }
-  }
-}
-
-function initMarkers(state, data) {
-  const { payload: { isMarkerOpen } } = data
-
-  return {
-    ...state,
-    isMarkerOpen,
-    currentMarker: isMarkerOpen.indexOf(true)
   }
 }
 


### PR DESCRIPTION
Bug fix: when signed out, loading the app would not initialize the map with a roadmap or profile preview.
Other changes:
- Added profile object to roadmap reducer
- MESA Home button always loads a random roadmap.
  - Significant bug remains: causes two API calls.
    - One upon clicking the MESA Home button.
    - Another upon GMap component mounting.
    - Since routing to the same url does not refresh the page (causing another fetchProfessional call in componentDidMount), this will have to do for now.
- GMap component will ALWAYS load a random roadmap unless using 'localhost:3000/roadmap/:id' route. This will load the appropriate user's roadmap.
- Removed routing to logged in user's roadmap as a compromise to fix the other issues.
