### PR TITLE
[#150] Minor changes to admin permission management and deletion responses

### DIFF
--- a/app/controllers/api/v1/api_base_controller.rb
+++ b/app/controllers/api/v1/api_base_controller.rb
@@ -49,15 +49,19 @@ module Api::V1
       end
 
       # Attempt to find admin permissions matching the specified user for the specified resource
-      def find_permissions_to_revoke(resource)
-        raise ExceptionTypes::BadRequestError.new("user_id must be present") unless params[:user_id].present?
-        
-        found_user = User.find(params[:user_id])
+      def find_permissions_to_revoke(resource, found_user)
         raise ExceptionTypes::UnauthorizedError.new("You are not authorized to modify the permissions for the user with ID #{found_user.id}") if found_user.super_admin?
 
         found_permissions = resource.permissions.where(user_id: found_user.id)
 
         found_permissions
+      end
+
+      # Determine whether or not an admin should be demoted after a revoked permission
+      def consider_demotion(admin_to_check)
+        if admin_to_check && admin_to_check.permissions.empty?
+          admin_to_check.update_columns(role: "user")
+        end
       end
 
     private

--- a/app/controllers/api/v1/experiences_controller.rb
+++ b/app/controllers/api/v1/experiences_controller.rb
@@ -42,6 +42,7 @@ module Api::V1
     # DELETE /v1/users/{user_id}/experiences/{id}
     def destroy
       @experience.destroy
+      render json: @experience, include: '', status: :ok
     end
 
     private

--- a/app/controllers/api/v1/media_controller.rb
+++ b/app/controllers/api/v1/media_controller.rb
@@ -36,6 +36,7 @@ module Api::V1
     # DELETE /v1/{mediable}/{mediable_id}/media/{id}
     def destroy
       @medium.destroy
+      render json: @medium, include: '', status: :ok
     end
 
     private

--- a/app/controllers/api/v1/programs_controller.rb
+++ b/app/controllers/api/v1/programs_controller.rb
@@ -4,6 +4,7 @@ module Api::V1
     before_action :set_program, only: [:show, :update, :grant_permission, :admins, :revoke_permission]
     before_action :allow_if_visible, except: [:index, :show]
     before_action :require_correct_admin, only: [:update, :grant_permission, :admins, :revoke_permission]
+    before_action :find_user, only: :revoke_permission
     before_action :validate_update_params, only: :update
     before_action :check_index_permission, only: :index
 
@@ -46,8 +47,10 @@ module Api::V1
 
     # DELETE /v1/programs/{id}/revoke
     def revoke_permission
-      permissions_to_destroy = find_permissions_to_revoke(@program)
+      permissions_to_destroy = find_permissions_to_revoke(@program, @user)
       permissions_to_destroy.destroy_all
+      consider_demotion(@user)
+      render json: @user, include: '', status: :ok
     end
 
     # Unreachable
@@ -74,6 +77,13 @@ module Api::V1
         if current_user.admin?
           raise ExceptionTypes::UnauthorizedError.new("You do not have permission to modify the program with ID #{@program.id}") unless @program.admins.exists? current_user.id
         end
+      end
+
+      # Find the specified user when preparing to revoke their permission 
+      def find_user
+        raise ExceptionTypes::BadRequestError.new("user_id must be present") unless params[:user_id].present?
+        
+        @user = User.find(params[:user_id])
       end
 
       # Validate the request payload when updating an existing program

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -56,6 +56,7 @@ module Api::V1
     # DELETE /v1/users/{id}
     def destroy
       @user.destroy
+      render json: @user, include: '', status: :ok
     end
 
     private


### PR DESCRIPTION
- When an admin has their last permission revoked through one of the new /revoke endpoints, their role will now be set back to user (demoted). The affected user will be sent back in the response body so that the FE can reflect the demotion on the admin page by removing the ability for super admins to downgrade their role in the users table since they are already downgraded.
- Up until now, our delete type endpoints responded with a 204 success status that also indicates no content in the response body. This causes an error on the FE as part of our middleware is unable to process an empty response. So, this PR also adjusts all deletion responses to contain the resource that was successfully deleted along with a 200 status code instead.