### PR TITLE
[#152] Make media URL optional for creation

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -3,6 +3,6 @@ class Medium < ApplicationRecord
   belongs_to :mediable, polymorphic: true
 
   # Validations
-  validates :mediable_id, :mediable_type, :category, :url, presence: { message: "%{attribute} must be present" }
+  validates :mediable_id, :mediable_type, :category, presence: { message: "%{attribute} must be present" }
   validates :category, inclusion: { in: %w(image video), message: "%{value} is not a valid category, must be image or video" }
 end


### PR DESCRIPTION
- Since a user may not have a profile photo on LinkedIn, we cannot force a URL to be included when creating media.