### PR TITLE
[#153] Switch from subdomain route constraint to api path requirement

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,19 +2,20 @@
 ----
 **Foreword**
 
-* All URLs for endpoints will be displayed as they will look in production (api.roadmaps.mesa.org). To consume the endpoints in your local environment (once they are merged), you must change the hostname portion of the URL to api.roadmaps.lvh.me:5000
+* All URLs for endpoints will be displayed as they will look in production (roadmaps.oregonmesa.org/api/v1/). To consume the endpoints in your local environment, you must change the hostname portion of the URL to localhost:5000
 * Anytime you see a ... symbol being used, it indicates that the payload continues in a similar fashion.
 * Certain field data types and response payload association inclusions are subject to change.
-* If the current user is a super admin and the payload contains a user resource at any level, the user resource will contain an extra attribute specifying their email
+* If the current user is a super admin and the payload contains a user resource at any level, the user resource will contain an extra attribute specifying their email.
+* The links in the example response payloads are not accurate to production.
 
 **1. [super_admin only] Get all users with optional query params on visible and/or role**
 
 * **URLs:**	
    
-  - **GET** `api.roadmaps.mesa.org/v1/users`
-  - **GET** `api.roadmaps.mesa.org/v1/users?role={string}`
-  - **GET** `api.roadmaps.mesa.org/v1/users?visible={boolean}`
-  - **GET** `api.roadmaps.mesa.org/v1/users?visible={boolean}&role={string}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users?role={string}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users?visible={boolean}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users?visible={boolean}&role={string}`
 
 * **Notes:**
   
@@ -72,7 +73,7 @@
 
 * **URL:**	
   
-  - **GET** `api.roadmaps.mesa.org/v1/users/{id}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users/{id}`
 
 * **Notes:**
   
@@ -220,7 +221,7 @@
 
 * **URL:**	
   
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/users/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/users/{id}`
 
 * **Notes:**
   
@@ -264,7 +265,7 @@
 
 * **URL:**	
   
-  - **DELETE** `api.roadmaps.mesa.org/v1/users/{id}`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/users/{id}`
 
 * **Notes:**
   
@@ -298,7 +299,7 @@
 
 * **URL:**	
   
-  - **GET** `api.roadmaps.mesa.org/v1/users/{id}/permissions`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users/{id}/permissions`
 
 * **Notes:**
   
@@ -360,7 +361,7 @@
 
 * **URL:**	
   
-  - **GET** `api.roadmaps.mesa.org/v1/users/random`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users/random`
 
 * **Notes:**
   
@@ -383,7 +384,7 @@
 
 * **URL:**	
   
-  - **GET** `api.roadmaps.mesa.org/v1/organizations/{id}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/organizations/{id}`
 
 * **Notes:**
   
@@ -542,7 +543,7 @@
 
 * **URL:**	
   
-  - **POST** `api.roadmaps.mesa.org/v1/organizations`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/organizations`
 
 * **Notes:**
   
@@ -606,7 +607,7 @@
 
 * **URL:**	
   
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/organizations/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/organizations/{id}`
 
 * **Notes:**
   
@@ -655,7 +656,7 @@
 
 * **URL:**
   
-  - **POST** `api.roadmaps.mesa.org/v1/organizations/{organization_id}/programs`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/organizations/{organization_id}/programs`
 
 * **Notes:**
   
@@ -703,7 +704,7 @@
 
 * **URL:**
   
-  - **GET** `api.roadmaps.mesa.org/v1/programs/{id}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/programs/{id}`
 
 * **Notes:**
   
@@ -831,7 +832,7 @@
 
 * **URL:**
   
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/programs/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/programs/{id}`
 
 * **Notes:**
   
@@ -878,7 +879,7 @@
 
 * **URL:**
   
-  - **POST** `api.roadmaps.mesa.org/v1/organizations/{organization_id}/permissions`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/organizations/{organization_id}/permissions`
 
 * **Notes:**
   
@@ -925,7 +926,7 @@
 
 * **URL:**
   
-  - **POST** `api.roadmaps.mesa.org/v1/programs/{program_id}/permissions`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/programs/{program_id}/permissions`
 
 * **Notes:**
   
@@ -972,9 +973,9 @@
 
 * **URLs:**
   
-  - **POST** `api.roadmaps.mesa.org/v1/users/{user_id}/media`
-  - **POST** `api.roadmaps.mesa.org/v1/organizations/{organization_id}/media`
-  - **POST** `api.roadmaps.mesa.org/v1/programs/{program_id}/media`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/users/{user_id}/media`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/organizations/{organization_id}/media`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/programs/{program_id}/media`
 
 * **Notes:**
   
@@ -1020,9 +1021,9 @@
 
 * **URLs:**
   
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/users/{user_id}/media/{id}`
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/organizations/{organization_id}/media/{id}`
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/programs/{program_id}/media/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/users/{user_id}/media/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/organizations/{organization_id}/media/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/programs/{program_id}/media/{id}`
 
 * **Notes:**
   
@@ -1062,9 +1063,9 @@
 
 * **URLs:**
   
-  - **DELETE** `api.roadmaps.mesa.org/v1/users/{user_id}/media/{id}`
-  - **DELETE** `api.roadmaps.mesa.org/v1/organizations/{organization_id}/media/{id}`
-  - **DELETE** `api.roadmaps.mesa.org/v1/programs/{program_id}/media/{id}`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/users/{user_id}/media/{id}`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/organizations/{organization_id}/media/{id}`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/programs/{program_id}/media/{id}`
 
 * **Notes:**
   
@@ -1094,7 +1095,7 @@
 
 * **URL:**
   
-  - **POST** `api.roadmaps.mesa.org/v1/users/{user_id}/experiences`
+  - **POST** `roadmaps.oregonmesa.org/api/v1/users/{user_id}/experiences`
 
 * **Notes:**
   
@@ -1180,7 +1181,7 @@
 
 * **URL:**
   
-  - **PUT/PATCH** `api.roadmaps.mesa.org/v1/users/{user_id}/experiences/{id}`
+  - **PUT/PATCH** `roadmaps.oregonmesa.org/api/v1/users/{user_id}/experiences/{id}`
 
 * **Notes:**
   
@@ -1255,7 +1256,7 @@
 
 * **URL:**
   
-  - **DELETE** `api.roadmaps.mesa.org/v1/users/{user_id}/experiences/{id}`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/users/{user_id}/experiences/{id}`
 
 * **Notes:**
   
@@ -1288,7 +1289,7 @@
 
 * **URL:**
   
-  - **GET** `api.roadmaps.mesa.org/v1/search?term={string}`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/search?term={string}`
 
 * **Notes:**
   
@@ -1298,7 +1299,7 @@
     
 * **Example Request:**
 
-  - **GET** `api.roadmaps.mesa.org/v1/search?term=manager`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/search?term=manager`
   
 * **Example Success Response:**
   
@@ -1378,7 +1379,7 @@
 
 * **URL:**
   
-  - **GET** `api.roadmaps.mesa.org/v1/organizations/{id}/admins`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/organizations/{id}/admins`
 
 * **Notes:**
   
@@ -1434,7 +1435,7 @@
 
 * **URL:**
   
-  - **GET** `api.roadmaps.mesa.org/v1/programs/{id}/admins`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/programs/{id}/admins`
 
 * **Notes:**
   
@@ -1488,7 +1489,7 @@
 
 * **URL:**
   
-  - **GET** `api.roadmaps.mesa.org/v1/users/current`
+  - **GET** `roadmaps.oregonmesa.org/api/v1/users/current`
 
 * **Notes:**
   
@@ -1511,7 +1512,7 @@
 
 * **URL:**
   
-  - **DELETE** `api.roadmaps.mesa.org/v1/organizations/{organization_id}/revoke`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/organizations/{organization_id}/revoke`
 
 * **Notes:**
   
@@ -1556,7 +1557,7 @@
 
 * **URL:**
   
-  - **DELETE** `api.roadmaps.mesa.org/v1/programs/{program_id}/revoke`
+  - **DELETE** `roadmaps.oregonmesa.org/api/v1/programs/{program_id}/revoke`
 
 * **Notes:**
   

--- a/app/serializers/api/v1/experience_serializer.rb
+++ b/app/serializers/api/v1/experience_serializer.rb
@@ -17,7 +17,7 @@ module Api::V1
       object.class.name
     end
     def link
-      view_context.v1_user_experience_url(object.user, object)
+      view_context.api_v1_user_experience_url(object.user, object)
     end
     def program_present?
       object.program.present?

--- a/app/serializers/api/v1/medium_serializer.rb
+++ b/app/serializers/api/v1/medium_serializer.rb
@@ -13,7 +13,7 @@ module Api::V1
       object.class.name
     end
     def link
-      view_context.polymorphic_url([:v1, object.mediable, object])
+      view_context.polymorphic_url([:api, :v1, object.mediable, object])
     end
   end
 end

--- a/app/serializers/api/v1/organization_serializer.rb
+++ b/app/serializers/api/v1/organization_serializer.rb
@@ -23,7 +23,7 @@ module Api::V1
       object.class.name
     end
     def link
-      view_context.v1_organization_url(object)
+      view_context.api_v1_organization_url(object)
     end
 
     # Available associations

--- a/app/serializers/api/v1/program_serializer.rb
+++ b/app/serializers/api/v1/program_serializer.rb
@@ -15,7 +15,7 @@ module Api::V1
       object.class.name
     end
     def link
-      view_context.v1_program_url(object)
+      view_context.api_v1_program_url(object)
     end
     def parent_organization_names
       object.organizations.where(visible: true).pluck(:name, :address_line_1, :address_line_2)

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -28,7 +28,7 @@ module Api::V1
       object.programs.where(id: current_program).pluck(:name).first if current_program.present?
     end
     def link
-      view_context.v1_user_url(object)
+      view_context.api_v1_user_url(object)
     end
     def super_admin?
       view_context.current_user && view_context.current_user.super_admin?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,58 +2,56 @@ Rails.application.routes.draw do
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }, skip: [:sessions, :registrations, :passwords]
 
-  constraints subdomain: 'api.roadmaps' do
-    scope module: 'api' do
-      namespace :v1 do
-        get 'search', to: 'api_base#search'
-        # Get all users (super_admin), Get a specific user with all their media and experiences, update a specific user, destroy a specific user
-        resources :users, only: [:index, :show, :update, :destroy] do
-          # Get a random user, Get the current user
-          collection do
-            get 'random'
-            get 'current'
-          end
-          # Get the permissions for a user
-          member do
-            get 'permissions'
-          end
-          # Create experiences for a user, update experiences for a user, destory experiences for a user
-          resources :experiences, only: [:create, :update, :destroy]
-          # Create media for a user, update media for a user, destroy media for a user
-          resources :media, only: [:create, :update, :destroy]
+  namespace :api do
+    namespace :v1 do
+      get 'search', to: 'api_base#search'
+      # Get all users (super_admin), Get a specific user with all their media and experiences, update a specific user, destroy a specific user
+      resources :users, only: [:index, :show, :update, :destroy] do
+        # Get a random user, Get the current user
+        collection do
+          get 'random'
+          get 'current'
         end
-
-        # Get all orgs (super_admin/optional), Get a specific organization with all their media, users, and programs, create a new organization,
-        # Update an org (admins)
-        resources :organizations, except: :destroy do
-          # Assign an admin to an org for permission to edit, revoke the permission for an admin to edit an org, 
-          # and get all admins for an org
-          member do
-            post 'permissions', to: 'organizations#grant_permission'
-            delete 'revoke', to: 'organizations#revoke_permission'
-            get 'admins'
-          end
-          # Create programs for an organization
-          resources :programs, only: :create
-          # Create media for orgs (admins), update media for orgs (admins), and destroy media for orgs (admins)
-          resources :media, only: [:create, :update, :destroy]
+        # Get the permissions for a user
+        member do
+          get 'permissions'
         end
-
-        # Get all progs (super_admin/optional), Get a specific program with all their media, users, and parent organizations,
-        # Update a prog (admins)
-        resources :programs, only: [:index, :show, :update] do
-          # Assign an admin to a program for permission to edit, revoke the permission for an admin to edit a prog,
-          # and get all admins for a program (super_admin)
-          member do
-            post 'permissions', to: 'programs#grant_permission'
-            delete 'revoke', to: 'programs#revoke_permission'
-            get 'admins'
-          end
-          # Create media for progs (admins), update media for progs (admins), and destroy media for progs (admins)
-          resources :media, only: [:create, :update, :destroy]
-        end
-
+        # Create experiences for a user, update experiences for a user, destory experiences for a user
+        resources :experiences, only: [:create, :update, :destroy]
+        # Create media for a user, update media for a user, destroy media for a user
+        resources :media, only: [:create, :update, :destroy]
       end
+
+      # Get all orgs (super_admin/optional), Get a specific organization with all their media, users, and programs, create a new organization,
+      # Update an org (admins)
+      resources :organizations, except: :destroy do
+        # Assign an admin to an org for permission to edit, revoke the permission for an admin to edit an org, 
+        # and get all admins for an org
+        member do
+          post 'permissions', to: 'organizations#grant_permission'
+          delete 'revoke', to: 'organizations#revoke_permission'
+          get 'admins'
+        end
+        # Create programs for an organization
+        resources :programs, only: :create
+        # Create media for orgs (admins), update media for orgs (admins), and destroy media for orgs (admins)
+        resources :media, only: [:create, :update, :destroy]
+      end
+
+      # Get all progs (super_admin/optional), Get a specific program with all their media, users, and parent organizations,
+      # Update a prog (admins)
+      resources :programs, only: [:index, :show, :update] do
+        # Assign an admin to a program for permission to edit, revoke the permission for an admin to edit a prog,
+        # and get all admins for a program (super_admin)
+        member do
+          post 'permissions', to: 'programs#grant_permission'
+          delete 'revoke', to: 'programs#revoke_permission'
+          get 'admins'
+        end
+        # Create media for progs (admins), update media for progs (admins), and destroy media for progs (admins)
+        resources :media, only: [:create, :update, :destroy]
+      end
+
     end
   end
 end

--- a/test/controllers/api/v1/experiences_controller_test.rb
+++ b/test/controllers/api/v1/experiences_controller_test.rb
@@ -16,7 +16,7 @@ module Api::V1
 
     test "should create experience" do
       assert_difference('Experience.count') do
-        post v1_user_experiences_url(@user), params: { experience: { award: @experience.award, end_date: @experience.end_date, organization_id: @experience.organization_id, program_id: @experience.program_id, start_date: @experience.start_date, title: @experience.title, user_id: @experience.user_id } }, as: :json
+        post api_v1_user_experiences_url(@user), params: { experience: { award: @experience.award, end_date: @experience.end_date, organization_id: @experience.organization_id, program_id: @experience.program_id, start_date: @experience.start_date, title: @experience.title, user_id: @experience.user_id } }, as: :json
       end
 
       assert_response 201
@@ -28,13 +28,13 @@ module Api::V1
     # end
 
     test "should update experience" do
-      patch v1_user_experience_url(@user, @experience), params: { experience: { award: @experience.award, end_date: @experience.end_date, organization_id: @experience.organization_id, program_id: @experience.program_id, start_date: @experience.start_date, title: @experience.title, user_id: @experience.user_id } }, as: :json
+      patch api_v1_user_experience_url(@user, @experience), params: { experience: { award: @experience.award, end_date: @experience.end_date, organization_id: @experience.organization_id, program_id: @experience.program_id, start_date: @experience.start_date, title: @experience.title, user_id: @experience.user_id } }, as: :json
       assert_response 200
     end
 
     test "should destroy experience" do
       assert_difference('Experience.count', -1) do
-        delete v1_user_experience_url(@user, @experience), as: :json
+        delete api_v1_user_experience_url(@user, @experience), as: :json
       end
 
       assert_response 204

--- a/test/controllers/api/v1/media_controller_test.rb
+++ b/test/controllers/api/v1/media_controller_test.rb
@@ -16,7 +16,7 @@ module Api::V1
 
     test "should create medium" do
       assert_difference('Medium.count') do
-        post v1_user_media_url(@user), params: { medium: { category: @medium.category, description: @medium.description, mediable_id: @medium.mediable_id, mediable_type: @medium.mediable_type, url: @medium.url } }, as: :json
+        post api_v1_user_media_url(@user), params: { medium: { category: @medium.category, description: @medium.description, mediable_id: @medium.mediable_id, mediable_type: @medium.mediable_type, url: @medium.url } }, as: :json
       end
 
       assert_response 201
@@ -28,13 +28,13 @@ module Api::V1
     # end
 
     test "should update medium" do
-      patch v1_user_medium_url(@user, @medium), params: { medium: { category: @medium.category, description: @medium.description, mediable_id: @medium.mediable_id, mediable_type: @medium.mediable_type, url: @medium.url } }, as: :json
+      patch api_v1_user_medium_url(@user, @medium), params: { medium: { category: @medium.category, description: @medium.description, mediable_id: @medium.mediable_id, mediable_type: @medium.mediable_type, url: @medium.url } }, as: :json
       assert_response 200
     end
 
     test "should destroy medium" do
       assert_difference('Medium.count', -1) do
-        delete v1_user_medium_url(@user, @medium), as: :json
+        delete api_v1_user_medium_url(@user, @medium), as: :json
       end
 
       assert_response 204

--- a/test/controllers/api/v1/organizations_controller_test.rb
+++ b/test/controllers/api/v1/organizations_controller_test.rb
@@ -9,25 +9,25 @@ module Api::V1
     # TODO: Improve existing tests and add test for grant_permission and admins
 
     test "should get index" do
-      get v1_organizations_url, as: :json
+      get api_v1_organizations_url, as: :json
       assert_response :success
     end
 
     test "should create organization" do
       assert_difference('Organization.count') do
-        post v1_organizations_url, params: { organization: { address_line_1: @organization.address_line_1, address_line_2: @organization.address_line_2, address_line_3: @organization.address_line_3, category: @organization.category, city: @organization.city, country: @organization.country, description: @organization.description, name: @organization.name, postal_code: @organization.postal_code, state: @organization.state, url: @organization.url, visible: @organization.visible } }, as: :json
+        post api_v1_organizations_url, params: { organization: { address_line_1: @organization.address_line_1, address_line_2: @organization.address_line_2, address_line_3: @organization.address_line_3, category: @organization.category, city: @organization.city, country: @organization.country, description: @organization.description, name: @organization.name, postal_code: @organization.postal_code, state: @organization.state, url: @organization.url, visible: @organization.visible } }, as: :json
       end
 
       assert_response 201
     end
 
     test "should show organization" do
-      get v1_organization_url(@organization), as: :json
+      get api_v1_organization_url(@organization), as: :json
       assert_response :success
     end
 
     test "should update organization" do
-      patch v1_organization_url(@organization), params: { organization: { address_line_1: @organization.address_line_1, address_line_2: @organization.address_line_2, address_line_3: @organization.address_line_3, category: @organization.category, city: @organization.city, country: @organization.country, description: @organization.description, name: @organization.name, postal_code: @organization.postal_code, state: @organization.state, url: @organization.url, visible: @organization.visible } }, as: :json
+      patch api_v1_organization_url(@organization), params: { organization: { address_line_1: @organization.address_line_1, address_line_2: @organization.address_line_2, address_line_3: @organization.address_line_3, category: @organization.category, city: @organization.city, country: @organization.country, description: @organization.description, name: @organization.name, postal_code: @organization.postal_code, state: @organization.state, url: @organization.url, visible: @organization.visible } }, as: :json
       assert_response 200
     end
 

--- a/test/controllers/api/v1/programs_controller_test.rb
+++ b/test/controllers/api/v1/programs_controller_test.rb
@@ -9,7 +9,7 @@ module Api::V1
     # TODO: Improve existing tests and add tests for new creation under organization, grant_permission, and admins
 
     test "should get index" do
-      get v1_programs_url, as: :json
+      get api_v1_programs_url, as: :json
       assert_response :success
     end
 
@@ -22,12 +22,12 @@ module Api::V1
     # end
 
     test "should show program" do
-      get v1_program_url(@program), as: :json
+      get api_v1_program_url(@program), as: :json
       assert_response :success
     end
 
     test "should update program" do
-      patch v1_program_url(@program), params: { program: { description: @program.description, name: @program.name, url: @program.url, visible: @program.visible } }, as: :json
+      patch api_v1_program_url(@program), params: { program: { description: @program.description, name: @program.name, url: @program.url, visible: @program.visible } }, as: :json
       assert_response 200
     end
 

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -9,7 +9,7 @@ module Api::V1
     # TODO: Improve existing tests and add tests for random, permissions, and linkedin
 
     test "should get index" do
-      get v1_users_url, as: :json
+      get api_v1_users_url, as: :json
       assert_response :success
     end
 
@@ -22,18 +22,18 @@ module Api::V1
     # end
 
     test "should show user" do
-      get v1_user_url(@user), as: :json
+      get api_v1_user_url(@user), as: :json
       assert_response :success
     end
 
     test "should update user" do
-      patch v1_user_url(@user), params: { user: { contact_url: @user.contact_url, first_name: @user.first_name, last_name: @user.last_name, linkedin_id: @user.linkedin_id, role: @user.role, visible: @user.visible } }, as: :json
+      patch api_v1_user_url(@user), params: { user: { contact_url: @user.contact_url, first_name: @user.first_name, last_name: @user.last_name, linkedin_id: @user.linkedin_id, role: @user.role, visible: @user.visible } }, as: :json
       assert_response 200
     end
 
     test "should destroy user" do
       assert_difference('User.count', -1) do
-        delete v1_user_url(@user), as: :json
+        api_delete v1_user_url(@user), as: :json
       end
 
       assert_response 204

--- a/test/controllers/api/v1/users_controller_test.rb
+++ b/test/controllers/api/v1/users_controller_test.rb
@@ -33,7 +33,7 @@ module Api::V1
 
     test "should destroy user" do
       assert_difference('User.count', -1) do
-        api_delete v1_user_url(@user), as: :json
+        delete api_v1_user_url(@user), as: :json
       end
 
       assert_response 204


### PR DESCRIPTION
- Routes file updated to require /api in path instead of api subdomain
- Url helper methods updated in serializers and tests to reflect correct links
- API documentation updated to show correct example URLs