### PR TITLE
[#158] Professional edit page. Removed extra margins to the right of the forms.

### DIFF
--- a/client/src/components/edit/NewExperiences.js
+++ b/client/src/components/edit/NewExperiences.js
@@ -111,7 +111,7 @@ const NewExperiences = props => {
           label="Add Experiences"
           fullWidth
           secondary
-          style={{ marginRight: '10%' }}
+          style={{ marginRight: '0%' }}
         />
       </div>
       <div>
@@ -171,7 +171,7 @@ const NewExperiences = props => {
                 />
               </div>
             </div>
-            <div style={{ width: '73vw' }}>
+            <div style={{ width: '74.8vw' }}>
               <Field
                 name={`${exp}.address`}
                 component={Places}

--- a/client/src/components/edit/edit.css
+++ b/client/src/components/edit/edit.css
@@ -19,12 +19,12 @@
 .EditMainGrid {
     overflow-y: scroll;
     overflow-x: hidden;
-    height: 71vh;
+    height: 69.5vh;
     margin-top: 1%;
     display: grid;
     grid-template-columns: 100%;
     grid-row-gap: 5%;
-    grid-template-areas: "personal" "media" "experience";
+    /* grid-template-areas: "personal" "media" "experience"; */
 }
 
 .EditPersonal {

--- a/client/src/components/edit/experience.css
+++ b/client/src/components/edit/experience.css
@@ -12,6 +12,7 @@
 
 .EditRight {
     height: auto;
+    width: 97%;
 }
 
 .EditOuterDiv {


### PR DESCRIPTION
The professional edit page should not have horizontal scrolling enabled anymore. All components fit within the width of the desktop view.